### PR TITLE
chunks start w/ 0

### DIFF
--- a/directaccess/__init__.py
+++ b/directaccess/__init__.py
@@ -37,7 +37,7 @@ def _chunks(iterable, n):
     :param n: max number of items in chunked list
     """
     l = len(iterable)
-    for ndx in range(1, l, n):
+    for ndx in range(0, l, n):
         yield iterable[ndx : min(ndx + n, l)]
 
 


### PR DESCRIPTION
I believe that one needs to start the chunks w/ 0 here.

Old version


```python
[x for x in _chunks([1,2,3,4,5], 2)] # [[2, 3], [4, 5]]
```

New

```python
[x for x in _chunks([1,2,3,4,5], 2)] # should yield [[1, 2], [3, 4], [5]]
```