### PR TITLE
Set minimum versions for requests and urllib3

### DIFF
--- a/directaccess/__init__.py
+++ b/directaccess/__init__.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 import requests
 import unicodecsv as csv
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 
 class DAAuthException(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-requests>=2.5.1,<3
+requests>=2.5.1
 unicodecsv==0.14.1
+urllib3>=1.26.0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,11 @@ setup(
     keywords=['enverus', 'drillinginfo', 'oil', 'gas'],
     packages=find_packages(exclude=('test*', )),
     package_dir={'directaccess': 'directaccess'},
-    install_requires=['requests>=2.5.1, <3', 'unicodecsv==0.14.1'],
+    install_requires=[
+        'requests>=2.16.0',
+        'unicodecsv==0.14.1',
+        'urllib3>=1.26.0',
+    ],
     extras_require={'pandas': pandas},
     cmdclass={
         'verify': VerifyVersionCommand,


### PR DESCRIPTION
Since #65, urllib3 [1.26+ (2020-11-10)](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#1260-2020-11-10) is required for `allowed_methods`.

Also since requests [2.16.0 (2017-05-26)](https://2.python-requests.org/en/master/community/updates/#id26), `urllib3` is no longer vendored inside `requests` - the `packages` module only exists for backwards compat (see [code](https://github.com/psf/requests/blob/main/requests/packages.py)). So best to require that requests version and import `urllib3` directly.

Finally, I removed the upper bound on requests. There has recently been a lot of discussion in Python land recently about how upper version constraints do more harm than good - including [this mega post](https://iscinumpy.dev/post/bound-version-constraints/).